### PR TITLE
feat: use Redis instead of non functional in-memory cache to work with serverless

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+DATABASE_URL="your_database_connection_string"
+
+DISCORD_CLIENT_ID="your_discord_client_id"
+DISCORD_CLIENT_SECRET="your_discord_client_secret"
+
+NEXTAUTH_SECRET="your_nextauth_secret_key"
+NEXTAUTH_URL="http://localhost:3000"
+
+NEXT_PUBLIC_ADMIN_ID="your_admin_discord_id"
+NODE_ENV="development" # or "production"
+
+UPSTASH_REDIS_REST_URL="your_upstash_redis_url"
+UPSTASH_REDIS_REST_TOKEN="your_upstash_redis_token"
+
+CRON_SECRET="your_cron_secret_for_vercel_cron_jobs"

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@prisma/client": "^6.8.2",
         "@sparticuz/chromium": "^133.0.0",
+        "@upstash/redis": "^1.35.0",
         "lucide-react": "^0.511.0",
         "next": "15.3.2",
         "next-auth": "^4.24.11",
@@ -1981,6 +1982,14 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.0.tgz",
+      "integrity": "sha512-WUm0Jz1xN4DBDGeJIi2Y0kVsolWRB2tsVds4SExaiLg4wBdHFMB+8IfZtBWr+BP0FvhuBr5G1/VLrJ9xzIWHsg==",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -6897,6 +6906,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@prisma/client": "^6.8.2",
     "@sparticuz/chromium": "^133.0.0",
+    "@upstash/redis": "^1.35.0",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
     "next-auth": "^4.24.11",

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest) {
   const testType = searchParams.get("testType") || "60";
 
   try {
-    const cacheStats = cacheManager.getCacheStats();
+    const cacheStats = await cacheManager.getCacheStats();
 
     const scores = await prisma.score.findMany({
       where: {

--- a/src/app/api/monkeytype-cache/force-update-all/route.ts
+++ b/src/app/api/monkeytype-cache/force-update-all/route.ts
@@ -1,8 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import cacheManager from '@/lib/monkeytypeCache';
 
-export async function GET() {
-  console.log('API: Received request to force update all Monkeytype cache.');
+export async function GET(req: NextRequest) {
+  if (req.headers.get('Authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  console.log('API: Received authorized request to force update all Monkeytype cache.');
   try {
     // Intentionally not awaiting this, as it can take a while
     // and we want to respond to the uptime bot quickly.

--- a/src/app/api/monkeytype-cache/force-update-all/route.ts
+++ b/src/app/api/monkeytype-cache/force-update-all/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import cacheManager from '@/lib/monkeytypeCache';
+
+export async function GET() {
+  console.log('API: Received request to force update all Monkeytype cache.');
+  try {
+    // Intentionally not awaiting this, as it can take a while
+    // and we want to respond to the uptime bot quickly.
+    // The update will run in the background.
+    cacheManager.forceUpdate().catch(error => {
+      console.error('API: Background cache update failed:', error);
+    });
+    
+    return NextResponse.json({ message: 'Global cache update initiated.' }, { status: 202 });
+  } catch (error) {
+    console.error('API: Error initiating global cache update:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ message: 'Error initiating global cache update', error: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/api/monkeytype-cache/route.ts
+++ b/src/app/api/monkeytype-cache/route.ts
@@ -5,8 +5,8 @@ import cacheManager from "@/lib/monkeytypeCache";
 
 export async function GET() {
   try {
-    const stats = cacheManager.getCacheStats();
-    const cachedData = cacheManager.getCachedData();
+    const stats = await cacheManager.getCacheStats();
+    const cachedData = await cacheManager.getCachedData();
 
     return NextResponse.json({
       stats,

--- a/src/app/api/refresh-scores/route.ts
+++ b/src/app/api/refresh-scores/route.ts
@@ -11,7 +11,7 @@ export async function POST() {
 
   try {
     await cacheManager.forceUpdate();
-    const stats = cacheManager.getCacheStats();
+    const stats = await cacheManager.getCacheStats();
     
     return NextResponse.json({ 
       message: "Cache updated successfully",
@@ -24,5 +24,20 @@ export async function POST() {
   } catch (err) {
     console.error("Cache refresh failed", err);
     return NextResponse.json({ error: "Failed to refresh cache" }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  try {
+    const stats = await cacheManager.getCacheStats();
+    return NextResponse.json({
+      message: "Cache stats fetched successfully",
+      userCount: stats.userCount,
+      freshDataCount: stats.freshDataCount,
+      lastGlobalUpdate: stats.lastGlobalUpdate,
+    });
+  } catch (error) {
+    console.error("Failed to fetch cache stats", error);
+    return NextResponse.json({ error: "Failed to fetch cache stats" }, { status: 500 });
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/monkeytype-cache/force-update-all",
-      "schedule": "0 */3 * * *"
+      "schedule": "0 */12 * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/monkeytype-cache/force-update-all",
+      "schedule": "0 */3 * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/monkeytype-cache/force-update-all",
-      "schedule": "0 */12 * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `MonkeytypeCacheManager` to transition from an in-memory cache to a Redis-based caching system. Additionally, it includes updates to API routes to ensure compatibility with the new caching mechanism and adds a scheduled cron job for cache updates.

### Transition to Redis-based caching:

* [`src/lib/monkeytypeCache.ts`](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL1-R12): Replaced the in-memory caching system with Redis for better scalability and persistence. Introduced Redis keys for user data, metadata (e.g., `META_LAST_GLOBAL_UPDATE_KEY`), and user sets. Updated methods like `getCachedData`, `getCacheStats`, and `updateCache` to interact with Redis. [[1]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL1-R12) [[2]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL30-R109) [[3]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL140-R128) [[4]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL149-R137) [[5]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL162-R152) [[6]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL187-R175) [[7]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL247-R242) [[8]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL267-R259) [[9]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL283-R281) [[10]](diffhunk://#diff-9fc90261de0169bb8c581e03b3ec5ab25089ca205ba4e52492d3af2c334361bbL314-R322)

### API route enhancements:

* [`src/app/api/monkeytype-cache/force-update-all/route.ts`](diffhunk://#diff-990739c238605a70aec5df6ac19ae21054b018a939a92427253d0687f9995707R1-R24): Added a new `GET` route to handle global cache updates, including authorization checks and background execution for uptime bot compatibility.
* [`src/app/api/refresh-scores/route.ts`](diffhunk://#diff-939e841ae85d27a471d9758b90a4b5ec992a6736f9cfee26a1417b2ef6008f84L14-R14): Added a `GET` endpoint to fetch cache statistics and updated the `POST` endpoint to use asynchronous Redis operations. [[1]](diffhunk://#diff-939e841ae85d27a471d9758b90a4b5ec992a6736f9cfee26a1417b2ef6008f84L14-R14) [[2]](diffhunk://#diff-939e841ae85d27a471d9758b90a4b5ec992a6736f9cfee26a1417b2ef6008f84R29-R43)
* [`src/app/api/update-personal-score/route.ts`](diffhunk://#diff-9c8b1869925844961fd4ee1e9fa37dc746873f6bd02f1eb76ac52990e614a47cL23-R26): Updated the `POST` endpoint to use asynchronous Redis methods for fetching and updating user data. Added error handling for malformed data. [[1]](diffhunk://#diff-9c8b1869925844961fd4ee1e9fa37dc746873f6bd02f1eb76ac52990e614a47cL23-R26) [[2]](diffhunk://#diff-9c8b1869925844961fd4ee1e9fa37dc746873f6bd02f1eb76ac52990e614a47cL36-R46)

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15): Added `@upstash/redis` as a dependency to enable Redis integration.

### Scheduled tasks:

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R1-R8): Added a cron job to trigger the `/api/monkeytype-cache/force-update-all` endpoint every three hours for automated cache updates.

### API method adjustments for async Redis:

* Updated all instances of `cacheManager.getCacheStats`, `cacheManager.getCachedData`, and similar methods across API routes to use `await` for compatibility with the new asynchronous Redis operations. [[1]](diffhunk://#diff-eabce22348a7d4cec1f1afe423f76be6304d77da1970dee4eed870e3c30120acL25-R25) [[2]](diffhunk://#diff-e29a7cd4a229a3eafc28d3878932123a10a7121ba795e224cf0e1c4e263e403dL8-R9) [[3]](diffhunk://#diff-939e841ae85d27a471d9758b90a4b5ec992a6736f9cfee26a1417b2ef6008f84L14-R14) [[4]](diffhunk://#diff-9c8b1869925844961fd4ee1e9fa37dc746873f6bd02f1eb76ac52990e614a47cL23-R26) [[5]](diffhunk://#diff-9c8b1869925844961fd4ee1e9fa37dc746873f6bd02f1eb76ac52990e614a47cL36-R46)

### .env.example

* Added .env.example