### PR TITLE
feat: update profiles dynamic page to use username instead of discordid

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -211,7 +211,7 @@ export default function LeaderboardPage() {
                                                                 className="w-8 h-8 sm:w-10 sm:h-10 rounded-full ring-2 ring-gray-700 group-hover:ring-gray-600 transition-all duration-200"
                                                             />
                                                         ) : (
-                                                            <Link href={`/profiles/${score.user.discordId}`}>
+                                                            <Link href={`/profiles/${score.user.username}`}>
                                                                 <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-gradient-to-br from-gray-600 to-gray-800 flex items-center justify-center ring-2 ring-gray-700 cursor-pointer">
                                                                     <span className="text-gray-300 font-semibold text-sm">
                                                                         {(score.user.displayname || score.user.username).charAt(0).toUpperCase()}
@@ -223,7 +223,7 @@ export default function LeaderboardPage() {
                                                     <div className="flex-1 min-w-0">
 
                                                         <div className="flex items-center gap-2 flex-wrap">
-                                                            <Link href={`/profiles/${score.user.discordId}`}>
+                                                            <Link href={`/profiles/${score.user.username}`}>
                                                                 <span className="text-white font-medium text-sm sm:text-base hover:text-blue-400 transition-colors cursor-pointer truncate">
                                                                     {score.user.displayname || score.user.username}
                                                                 </span>

--- a/src/app/profiles/[name]/page.tsx
+++ b/src/app/profiles/[name]/page.tsx
@@ -27,10 +27,10 @@ const SocialIcon = ({ label }: { label: string }) => {
     }
 };
 
-export default async function UserProfile({ params }: { params: Promise<{ id: string }> }) {
-    const userId = (await params).id;
-    const user = await prisma.user.findUnique({
-        where: { discordId: userId },
+export default async function UserProfile({ params }: { params: Promise<{ name: string }> }) {
+    const username = (await params).name;
+    const user = await prisma.user.findFirst({
+        where: { username: username },
         include: { scores: true },
     });
 


### PR DESCRIPTION
This pull request updates the application to use usernames instead of Discord IDs for user profile links and queries. The changes primarily focus on improving user experience and aligning the app's functionality with usernames as identifiers.

### Updates to user profile links:

* In `src/app/leaderboard/page.tsx`, updated the `href` attribute in `<Link>` components to use `score.user.username` instead of `score.user.discordId`. This ensures profile links are based on usernames. [[1]](diffhunk://#diff-b1a19a4e637bbf289d5fc6edc5a2d6c9ae7f83f2aa13eb914bfd492444003377L214-R214) [[2]](diffhunk://#diff-b1a19a4e637bbf289d5fc6edc5a2d6c9ae7f83f2aa13eb914bfd492444003377L226-R226)

### Updates to user profile queries:

* Renamed the file `src/app/profiles/[id]/page.tsx` to `src/app/profiles/[name]/page.tsx` to reflect the change from using IDs to usernames. ([src/app/profiles/[name]/page.tsxL30-R33](diffhunk://#diff-23308b99dbe7a462b903fe32a590f4a272ec7577fee627a782da959c018aadf1L30-R33))
* Updated the `UserProfile` function to query the database using `username` instead of `discordId` by changing the `findUnique` method to `findFirst` and modifying the parameter structure accordingly. ([src/app/profiles/[name]/page.tsxL30-R33](diffhunk://#diff-23308b99dbe7a462b903fe32a590f4a272ec7577fee627a782da959c018aadf1L30-R33))